### PR TITLE
Fix css

### DIFF
--- a/src/ui/DetailsWeblink.svelte
+++ b/src/ui/DetailsWeblink.svelte
@@ -8,7 +8,7 @@
 <style>
     div {
         display: flex;
-        aling-items: center;
+        align-items: center;
     }
 
     a {

--- a/src/ui/DropdownList.svelte
+++ b/src/ui/DropdownList.svelte
@@ -40,7 +40,7 @@
         font-size: 18px;
         padding: 8px 12px;
         background-color: #f2f2f2;
-        boder-color: #ddd;
+        border-color: #ddd;
     }
 
     .dropdown-menu {

--- a/src/ui/PanelButton.svelte
+++ b/src/ui/PanelButton.svelte
@@ -12,7 +12,7 @@
         border-left: 1px solid white;
         border-right: 1px solid #bbb;
         border-top: none;
-        border-bootom: none;
+        border-bottom: none;
     }
 </style>
 


### PR DESCRIPTION
Fix three typos which were flagged by [W3C Validator](https://validator.w3.org/unicorn/check?ucn_uri=https%3A%2F%2Fhiking.waymarkedtrails.org%2F&ucn_task=conformance#).

Fixes
- Property “aling-items” doesn't exist. The closest matching property name is “align-items” : center
- Property “boder-color” doesn't exist. The closest matching property name is “border-color” : #ddd
- Property “border-bootom” doesn't exist. The closest matching property name is “border-bottom” : none